### PR TITLE
Fix: Mark `firewallAdmin()` as an interface override

### DIFF
--- a/packages/firewall-consumer/contracts/FirewallConsumerBase.sol
+++ b/packages/firewall-consumer/contracts/FirewallConsumerBase.sol
@@ -213,7 +213,7 @@ contract FirewallConsumerBase is IFirewallConsumer, Context {
     /**
      * @dev View function for the firewall admin
      */
-    function firewallAdmin() external view returns (address) {
+    function firewallAdmin() external override view returns (address) {
         return _getAddressBySlot(FIREWALL_ADMIN_STORAGE_SLOT);
     }
 


### PR DESCRIPTION
This change marks the `firewallAdmin()` getter method as an `override` to prevent compilation conflicts in earlier Solidity versions.