### PR TITLE
Feat: new simple firewall consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ For any help or questions, please open an issue on this repository, or contact u
 Ironblocks is dedicated to providing advanced security solutions for blockchain applications. Our OnChain Firewall is designed to safeguard your smart contracts with state-of-the-art security policies and tools.
 
 Visit us at [www.ironblocks.com](https://www.ironblocks.com)
+
+Learn more at [Ironblocks Documentation](https://docs.ironblocks.com)

--- a/packages/firewall-consumer/contracts/FirewallConsumerBase.sol
+++ b/packages/firewall-consumer/contracts/FirewallConsumerBase.sol
@@ -31,7 +31,7 @@ contract FirewallConsumerBase is IFirewallConsumer, Context {
     bytes4 private constant SUPPORTS_APPROVE_VIA_SIGNATURE_INTERFACE_ID = bytes4(0x0c908cff); // sighash of approveCallsViaSignature
 
     // This slot is special since it's used for mappings and not a single value
-    bytes32 private constant APPROVED_VENN_POLICIES_MAPPING_SLOT = bytes32(uint256(keccak256("eip1967.approved.venn.policies")) - 1);
+    bytes32 private constant APPROVED_VENN_POLICY_SLOT = bytes32(uint256(keccak256("eip1967.approved.venn.policy")) - 1);
 
     event FirewallAdminUpdated(address newAdmin);
     event FirewallUpdated(address newFirewall);
@@ -148,7 +148,7 @@ contract FirewallConsumerBase is IFirewallConsumer, Context {
         // We use the same logic that solidity uses for mapping locations, but we add a pseudorandom
         // constant "salt" instead of a constant placeholder so that there are no storage collisions
         // if adding this to an upgradeable contract implementation
-        bytes32 _slot = keccak256(abi.encode(APPROVED_VENN_POLICIES_MAPPING_SLOT, vennPolicy));
+        bytes32 _slot = keccak256(abi.encode(APPROVED_VENN_POLICY_SLOT, vennPolicy));
         bool isApprovedVennPolicy = _getValueBySlot(_slot) != bytes32(0);
         require(isApprovedVennPolicy, "FirewallConsumer: Not approved Venn policy");
         require(ERC165Checker.supportsERC165InterfaceUnchecked(vennPolicy, SUPPORTS_APPROVE_VIA_SIGNATURE_INTERFACE_ID));
@@ -204,7 +204,7 @@ contract FirewallConsumerBase is IFirewallConsumer, Context {
      * @param status status of the Venn policy
      */
     function setApprovedVennPolicy(address vennPolicy, bool status) external onlyFirewallAdmin {
-        bytes32 _slot = keccak256(abi.encode(APPROVED_VENN_POLICIES_MAPPING_SLOT, vennPolicy));
+        bytes32 _slot = keccak256(abi.encode(APPROVED_VENN_POLICY_SLOT, vennPolicy));
         assembly {
             sstore(_slot, status)
         }

--- a/packages/firewall-consumer/contracts/consumers/FirewallConsumerStorage.sol
+++ b/packages/firewall-consumer/contracts/consumers/FirewallConsumerStorage.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: UNLICENSED
+// See LICENSE file for full license text.
+// Copyright (c) Ironblocks 2024
+pragma solidity ^0.8.0;
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {IFirewall} from "../interfaces/IFirewall.sol";
+import {IFirewallConsumerStorage} from "../interfaces/IFirewallConsumerStorage.sol";
+
+/**
+ * @title Firewall Consumer Storage Contract
+ * @author David Benchimol @ Ironblocks
+ * @dev This contract is a parent contract that can be used to add firewall protection to any contract.
+ *
+ * The contract must define a firewall contract which will manage the policies that are applied to the contract.
+ * It also must define a firewall admin which will be able to add and remove policies.
+ *
+ */
+contract FirewallConsumerStorage is IFirewallConsumerStorage {
+
+    // This slot is used to store the firewall address
+    bytes32 private constant FIREWALL_STORAGE_SLOT = bytes32(uint256(keccak256("eip1967.firewall")) - 1);
+
+    // This slot is used to store the firewall admin address
+    bytes32 private constant FIREWALL_ADMIN_STORAGE_SLOT = bytes32(uint256(keccak256("eip1967.firewall.admin")) - 1);
+
+    // This slot is used to store the new firewall admin address (when changing admin)
+    bytes32 private constant NEW_FIREWALL_ADMIN_STORAGE_SLOT = bytes32(uint256(keccak256("eip1967.new.firewall.admin")) - 1);
+
+    // This slot is special since it's used for mappings and not a single value
+    bytes32 private constant APPROVED_TARGET_SLOT = bytes32(uint256(keccak256("eip1967.approved.target")) - 1);
+
+    bytes32 private constant USER_NATIVE_FEE_SLOT = bytes32(uint256(keccak256("eip1967.user.native.fee")) - 1);
+
+    event FirewallAdminUpdated(address newAdmin);
+    event FirewallUpdated(address newFirewall);
+
+    /**
+     * @dev modifier similar to onlyOwner, but for the firewall admin.
+     */
+    modifier onlyFirewallAdmin() {
+        require(msg.sender == _getAddressBySlot(FIREWALL_ADMIN_STORAGE_SLOT), "FirewallConsumer: not firewall admin");
+        _;
+    }
+
+    /**
+     * @dev Initializes a contract protected by a firewall, with a firewall address and a firewall admin.
+     */
+    constructor(
+        address _firewall,
+        address _firewallAdmin
+    ) {
+        _setAddressBySlot(FIREWALL_STORAGE_SLOT, _firewall);
+        _setAddressBySlot(FIREWALL_ADMIN_STORAGE_SLOT, _firewallAdmin);
+    }
+
+    function getApprovedTarget() external view returns (address) {
+        return _getAddressBySlot(APPROVED_TARGET_SLOT);
+    }
+
+    function getUserNativeFee() external view returns (uint256) {
+        return uint256(_getValueBySlot(USER_NATIVE_FEE_SLOT));
+    }
+
+    function getFirewall() external view returns (address) {
+        return _getAddressBySlot(FIREWALL_STORAGE_SLOT);
+    }
+
+    function getFirewallAdmin() external view returns (address) {
+        return _getAddressBySlot(FIREWALL_ADMIN_STORAGE_SLOT);
+    }
+
+    /**
+     * @dev Allows firewall admin to set target.
+     * IMPORTANT: Only set approved target if you know what you're doing. Anyone can cause this contract
+     * to send any data to an approved target.
+     *
+     * @param target address of the target
+     */
+    function setTarget(address target) external onlyFirewallAdmin {
+        _setAddressBySlot(APPROVED_TARGET_SLOT, target);
+    }
+
+    /**
+     * @dev Allows firewall admin to set user native fee for safeFunctionCall.
+     *
+     * @param fee native fee for the user
+     */
+    function setUserNativeFee(uint256 fee) external onlyFirewallAdmin {
+        _setValueBySlot(USER_NATIVE_FEE_SLOT, fee);
+    }
+
+    /**
+     * @dev Admin only function allowing the consumers admin to set the firewall address.
+     * @param _firewall address of the firewall
+     */
+    function setFirewall(address _firewall) external onlyFirewallAdmin {
+        _setAddressBySlot(FIREWALL_STORAGE_SLOT, _firewall);
+        emit FirewallUpdated(_firewall);
+    }
+
+    /**
+     * @dev Admin only function, sets new firewall admin. New admin must accept.
+     * @param _firewallAdmin address of the new firewall admin
+     */
+    function setFirewallAdmin(address _firewallAdmin) external onlyFirewallAdmin {
+        require(_firewallAdmin != address(0), "FirewallConsumer: zero address");
+        _setAddressBySlot(NEW_FIREWALL_ADMIN_STORAGE_SLOT, _firewallAdmin);
+    }
+
+    /**
+     * @dev Accept the role as firewall admin.
+     */
+    function acceptFirewallAdmin() external {
+        require(msg.sender == _getAddressBySlot(NEW_FIREWALL_ADMIN_STORAGE_SLOT), "FirewallConsumer: not new admin");
+        _setAddressBySlot(FIREWALL_ADMIN_STORAGE_SLOT, msg.sender);
+        emit FirewallAdminUpdated(msg.sender);
+    }
+
+    /**
+     * @dev Internal helper function to set an address in a storage slot
+     * @param _slot storage slot
+     * @param _address address to be set
+     */
+    function _setAddressBySlot(bytes32 _slot, address _address) internal {
+        assembly {
+            sstore(_slot, _address)
+        }
+    }
+
+    /**
+     * @dev Internal helper function to get an address from a storage slot
+     * @param _slot storage slot
+     * @return _address from the storage slot
+     */
+    function _getAddressBySlot(bytes32 _slot) internal view returns (address _address) {
+        assembly {
+            _address := sload(_slot)
+        }
+    }
+
+    function _setValueBySlot(bytes32 _slot, uint256 _value) internal {
+        assembly {
+            sstore(_slot, _value)
+        }
+    }
+
+    /**
+     * @dev Internal helper function to get a value from a storage slot
+     * @param _slot storage slot
+     * @return _value from the storage slot
+     */
+    function _getValueBySlot(bytes32 _slot) internal view returns (bytes32 _value) {
+        assembly {
+            _value := sload(_slot)
+        }
+    }
+}

--- a/packages/firewall-consumer/contracts/consumers/FirewallConsumerStorage.sol
+++ b/packages/firewall-consumer/contracts/consumers/FirewallConsumerStorage.sol
@@ -28,7 +28,7 @@ contract FirewallConsumerStorage is IFirewallConsumerStorage {
     bytes32 private constant NEW_FIREWALL_ADMIN_STORAGE_SLOT = bytes32(uint256(keccak256("eip1967.new.firewall.admin")) - 1);
 
     // This slot is special since it's used for mappings and not a single value
-    bytes32 private constant APPROVED_TARGET_SLOT = bytes32(uint256(keccak256("eip1967.approved.target")) - 1);
+    bytes32 private constant APPROVED_VENN_POLICY_SLOT = bytes32(uint256(keccak256("eip1967.approved.venn.policy")) - 1);
 
     bytes32 private constant USER_NATIVE_FEE_SLOT = bytes32(uint256(keccak256("eip1967.user.native.fee")) - 1);
 
@@ -54,8 +54,8 @@ contract FirewallConsumerStorage is IFirewallConsumerStorage {
         _setAddressBySlot(FIREWALL_ADMIN_STORAGE_SLOT, _firewallAdmin);
     }
 
-    function getApprovedTarget() external view returns (address) {
-        return _getAddressBySlot(APPROVED_TARGET_SLOT);
+    function getApprovedVennPolicy() external view returns (address) {
+        return _getAddressBySlot(APPROVED_VENN_POLICY_SLOT);
     }
 
     function getUserNativeFee() external view returns (uint256) {
@@ -71,14 +71,14 @@ contract FirewallConsumerStorage is IFirewallConsumerStorage {
     }
 
     /**
-     * @dev Allows firewall admin to set target.
-     * IMPORTANT: Only set approved target if you know what you're doing. Anyone can cause this contract
-     * to send any data to an approved target.
+     * @dev Allows firewall admin to set Venn policy.
+     * IMPORTANT: Only set approved Venn policy if you know what you're doing. Anyone can cause this contract
+     * to send any data to an approved Venn policy.
      *
-     * @param target address of the target
+     * @param vennPolicy address of the Venn policy
      */
-    function setTarget(address target) external onlyFirewallAdmin {
-        _setAddressBySlot(APPROVED_TARGET_SLOT, target);
+    function setVennPolicy(address vennPolicy) external onlyFirewallAdmin {
+        _setAddressBySlot(APPROVED_VENN_POLICY_SLOT, vennPolicy);
     }
 
     /**

--- a/packages/firewall-consumer/contracts/consumers/SimpleUpgradeableFirewallConsumer.sol
+++ b/packages/firewall-consumer/contracts/consumers/SimpleUpgradeableFirewallConsumer.sol
@@ -56,7 +56,7 @@ contract SimpleUpgradeableFirewallConsumer is IFirewallConsumer, Initializable {
     }
 
     /**
-     * @dev Allows calling an approved external target before executing a method.
+     * @dev Allows calling an approved external Venn policy before executing a method.
      *
      * This can be used for multiple purposes, but the initial one is to call `approveCallsViaSignature` before
      * executing a function, allowing synchronous transaction approvals.
@@ -64,18 +64,18 @@ contract SimpleUpgradeableFirewallConsumer is IFirewallConsumer, Initializable {
      * NOTE: If userNativeFee is non zero, functions using this must take into account that
      * the value received will be slightly less than msg.value due to the fee.
      *
-     * @param targetPayload payload to be sent to the target
-     * @param data data to be executed after the target call
+     * @param vennPolicyPayload payload to be sent to the Venn policy
+     * @param data data to be executed after the Venn policy call
      */
     function safeFunctionCall(
-        bytes calldata targetPayload,
+        bytes calldata vennPolicyPayload,
         bytes calldata data
     ) external payable {
         address firewallConsumerStorage = _getFirewallConsumerStorage();
-        address target = IFirewallConsumerStorage(firewallConsumerStorage).getApprovedTarget();
+        address vennPolicy = IFirewallConsumerStorage(firewallConsumerStorage).getApprovedVennPolicy();
         uint256 userNativeFee = IFirewallConsumerStorage(firewallConsumerStorage).getUserNativeFee();
         require(msg.value >= userNativeFee, "FirewallConsumer: Not enough native value for fee");
-        (bool success,) = target.call{value: userNativeFee}(targetPayload);
+        (bool success,) = vennPolicy.call{value: userNativeFee}(vennPolicyPayload);
         require(success);
         Address.functionDelegateCall(address(this), data);
     }

--- a/packages/firewall-consumer/contracts/consumers/SimpleUpgradeableFirewallConsumer.sol
+++ b/packages/firewall-consumer/contracts/consumers/SimpleUpgradeableFirewallConsumer.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: UNLICENSED
+// See LICENSE file for full license text.
+// Copyright (c) Ironblocks 2024
+pragma solidity ^0.8.0;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {IFirewall} from "../interfaces/IFirewall.sol";
+import {IFirewallConsumer} from "../interfaces/IFirewallConsumer.sol";
+import {IFirewallConsumerStorage} from "../interfaces/IFirewallConsumerStorage.sol";
+
+/**
+ * @title Firewall Minimal Upgradeable Consumer Contract
+ * @author David Benchimol @ Ironblocks
+ * @dev This contract is a parent contract that can be used to add firewall protection to any contract.
+ *
+ * The contract is the most minimal upgradeable contract that implements the FirewallConsumer interface.
+ *
+ */
+contract SimpleUpgradeableFirewallConsumer is IFirewallConsumer, Initializable {
+
+    // This slot is used to store the consumer storage address
+    bytes32 private constant FIREWALL_CONSUMER_STORAGE_SLOT = bytes32(uint256(keccak256("eip1967.firewall.consumer.storage")) - 1);
+
+    /**
+     * @dev modifier that will run the preExecution and postExecution hooks of the firewall, applying each of
+     * the subscribed policies.
+     *
+     * NOTE: Applying this modifier on functions that exit execution flow by an inline assmebly "return" call will
+     * prevent the postExecution hook from running - breaking the protection provided by the firewall.
+     * If you have any questions, please refer to the Firewall's documentation and/or contact our support.
+     */
+    modifier firewallProtected() {
+        address firewallConsumerStorage = _getFirewallConsumerStorage();
+        address firewall = IFirewallConsumerStorage(firewallConsumerStorage).getFirewall();
+        if (firewall == address(0)) {
+            _;
+            return;
+        }
+        // We do this because msg.value can only be accessed in payable functions.
+        uint256 value;
+        assembly {
+            value := callvalue()
+        }
+        IFirewall(firewall).preExecution(msg.sender, msg.data, value);
+        _;
+        IFirewall(firewall).postExecution(msg.sender, msg.data, value);
+    }
+
+    /**
+     * @dev modifier similar to onlyOwner, but for the firewall admin.
+     */
+    modifier onlyFirewallAdmin() {
+        require(msg.sender == _getFirewallAdmin(), "FirewallConsumer: not firewall admin");
+        _;
+    }
+
+    /**
+     * @dev Allows calling an approved external target before executing a method.
+     *
+     * This can be used for multiple purposes, but the initial one is to call `approveCallsViaSignature` before
+     * executing a function, allowing synchronous transaction approvals.
+     *
+     * NOTE: If userNativeFee is non zero, functions using this must take into account that
+     * the value received will be slightly less than msg.value due to the fee.
+     *
+     * @param targetPayload payload to be sent to the target
+     * @param data data to be executed after the target call
+     */
+    function safeFunctionCall(
+        bytes calldata targetPayload,
+        bytes calldata data
+    ) external payable {
+        address firewallConsumerStorage = _getFirewallConsumerStorage();
+        address target = IFirewallConsumerStorage(firewallConsumerStorage).getApprovedTarget();
+        uint256 userNativeFee = IFirewallConsumerStorage(firewallConsumerStorage).getUserNativeFee();
+        require(msg.value >= userNativeFee, "FirewallConsumer: Not enough native value for fee");
+        (bool success,) = target.call{value: userNativeFee}(targetPayload);
+        require(success);
+        Address.functionDelegateCall(address(this), data);
+    }
+
+    /**
+     * @dev View function for the firewall admin
+     */
+    function firewallAdmin() external view returns (address) {
+        return _getFirewallAdmin();
+    }
+
+    function setFirewallConsumerStorage(address _firewallConsumerStorage) external onlyFirewallAdmin {
+        _setAddressBySlot(FIREWALL_CONSUMER_STORAGE_SLOT, _firewallConsumerStorage);
+    }
+
+    function __SimpleUpgradeableFirewallConsumer_init(address _firewallConsumerStorage) internal onlyInitializing {
+        _setAddressBySlot(FIREWALL_CONSUMER_STORAGE_SLOT, _firewallConsumerStorage);
+    }
+
+    /**
+     * @dev Internal view function for the firewall admin
+     */
+    function _getFirewallAdmin() internal view returns (address) {
+        address firewallConsumerStorage = _getFirewallConsumerStorage();
+        return IFirewallConsumerStorage(firewallConsumerStorage).getFirewallAdmin();
+    }
+
+    /**
+     * @dev Internal view function for the consumer storage
+     */
+    function _getFirewallConsumerStorage() internal view returns (address) {
+        return _getAddressBySlot(FIREWALL_CONSUMER_STORAGE_SLOT);
+    }
+
+
+    /**
+     * @dev Internal helper function to set an address in a storage slot
+     * @param _slot storage slot
+     * @param _address address to be set
+     */
+    function _setAddressBySlot(bytes32 _slot, address _address) internal {
+        assembly {
+            sstore(_slot, _address)
+        }
+    }
+
+    /**
+     * @dev Internal helper function to get an address from a storage slot
+     * @param _slot storage slot
+     * @return _address from the storage slot
+     */
+    function _getAddressBySlot(bytes32 _slot) internal view returns (address _address) {
+        assembly {
+            _address := sload(_slot)
+        }
+    }
+
+}

--- a/packages/firewall-consumer/contracts/interfaces/IFirewallConsumerStorage.sol
+++ b/packages/firewall-consumer/contracts/interfaces/IFirewallConsumerStorage.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+// See LICENSE file for full license text.
+// Copyright (c) Ironblocks 2024
+pragma solidity ^0.8.0;
+
+interface IFirewallConsumerStorage {
+    function getFirewallAdmin() external view returns (address);
+    function getFirewall() external view returns (address);
+    function getApprovedTarget() external view returns (address);
+    function getUserNativeFee() external view returns (uint256);
+}

--- a/packages/firewall-consumer/contracts/interfaces/IFirewallConsumerStorage.sol
+++ b/packages/firewall-consumer/contracts/interfaces/IFirewallConsumerStorage.sol
@@ -6,6 +6,6 @@ pragma solidity ^0.8.0;
 interface IFirewallConsumerStorage {
     function getFirewallAdmin() external view returns (address);
     function getFirewall() external view returns (address);
-    function getApprovedTarget() external view returns (address);
+    function getApprovedVennPolicy() external view returns (address);
     function getUserNativeFee() external view returns (uint256);
 }

--- a/packages/firewall-consumer/hardhat.config.js
+++ b/packages/firewall-consumer/hardhat.config.js
@@ -1,0 +1,49 @@
+require('dotenv').config();
+require('@nomiclabs/hardhat-waffle');
+require('@nomiclabs/hardhat-etherscan');
+require('@openzeppelin/hardhat-upgrades');
+require('hardhat-abi-exporter');
+require('hardhat-gas-reporter');
+require('solidity-coverage');
+
+module.exports = {
+    networks: {
+        local: {
+            url: 'http://localhost:8545',
+        },
+        matic: {
+            url: 'https://polygon-rpc.com/',
+            accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+        },
+        goerli: {
+            url: 'https://rpc.ankr.com/eth_goerli',
+            accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+        },
+        sepolia: {
+            url: 'https://ethereum-sepolia.publicnode.com',
+            accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+            gasPrice: 100000000000,
+        },
+        bscTestnet: {
+            url: 'https://bsc-testnet.publicnode.com',
+            accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+        },
+    },
+    etherscan: {
+        apiKey: process.env.API_KEY,
+    },
+    solidity: {
+        version: '0.8.19',
+        settings: {
+            optimizer: {
+                enabled: true,
+                runs: 10000,
+            },
+        },
+    },
+    abiExporter: {
+        runOnCompile: true,
+        clear: true,
+        flat: true,
+    },
+};

--- a/packages/onchain-firewall/contracts/FirewallConsumerBase.sol
+++ b/packages/onchain-firewall/contracts/FirewallConsumerBase.sol
@@ -31,7 +31,7 @@ contract FirewallConsumerBase is IFirewallConsumer, Context {
     bytes4 private constant SUPPORTS_APPROVE_VIA_SIGNATURE_INTERFACE_ID = bytes4(0x0c908cff); // sighash of approveCallsViaSignature
 
     // This slot is special since it's used for mappings and not a single value
-    bytes32 private constant APPROVED_VENN_POLICIES_MAPPING_SLOT = bytes32(uint256(keccak256("eip1967.approved.venn.policies")) - 1);
+    bytes32 private constant APPROVED_VENN_POLICY_SLOT = bytes32(uint256(keccak256("eip1967.approved.venn.policy")) - 1);
 
     event FirewallAdminUpdated(address newAdmin);
     event FirewallUpdated(address newFirewall);
@@ -148,7 +148,7 @@ contract FirewallConsumerBase is IFirewallConsumer, Context {
         // We use the same logic that solidity uses for mapping locations, but we add a pseudorandom
         // constant "salt" instead of a constant placeholder so that there are no storage collisions
         // if adding this to an upgradeable contract implementation
-        bytes32 _slot = keccak256(abi.encode(APPROVED_VENN_POLICIES_MAPPING_SLOT, vennPolicy));
+        bytes32 _slot = keccak256(abi.encode(APPROVED_VENN_POLICY_SLOT, vennPolicy));
         bool isApprovedVennPolicy = _getValueBySlot(_slot) != bytes32(0);
         require(isApprovedVennPolicy, "FirewallConsumer: Not approved Venn policy");
         require(ERC165Checker.supportsERC165InterfaceUnchecked(vennPolicy, SUPPORTS_APPROVE_VIA_SIGNATURE_INTERFACE_ID));
@@ -204,7 +204,7 @@ contract FirewallConsumerBase is IFirewallConsumer, Context {
      * @param status status of the Venn policy
      */
     function setApprovedVennPolicy(address vennPolicy, bool status) external onlyFirewallAdmin {
-        bytes32 _slot = keccak256(abi.encode(APPROVED_VENN_POLICIES_MAPPING_SLOT, vennPolicy));
+        bytes32 _slot = keccak256(abi.encode(APPROVED_VENN_POLICY_SLOT, vennPolicy));
         assembly {
             sstore(_slot, status)
         }

--- a/packages/onchain-firewall/test/approvedCallsPolicy.js
+++ b/packages/onchain-firewall/test/approvedCallsPolicy.js
@@ -178,7 +178,7 @@ describe('Approved Calls Policy', () => {
         });
     });
 
-    it('Firewall safeFunctionCall cannot call unapproved target', async function () {
+    it('Firewall safeFunctionCall cannot call unapproved vennPolicy', async function () {
         const depositPayload = sampleConsumerIface.encodeFunctionData('deposit()');
         const depositCallHash = ethers.utils.solidityKeccak256(
             ['address', 'address', 'address', 'bytes', 'uint256'],
@@ -213,13 +213,13 @@ describe('Approved Calls Policy', () => {
             sampleConsumer
                 .connect(addr1)
                 .safeFunctionCall(approvedCallsPolicy.address, approvePayload, depositPayload, { value: ethers.utils.parseEther('1') })
-        ).to.be.revertedWith("FirewallConsumer: Not approved target");
+        ).to.be.revertedWith("FirewallConsumer: Not approved Venn policy");
     });
 
 
-    it('Firewall safeFunctionCall cannot call approved then unapproved target', async function () {
-        await sampleConsumer.setApprovedTarget(approvedCallsPolicy.address, true);
-        await sampleConsumer.setApprovedTarget(approvedCallsPolicy.address, false);
+    it('Firewall safeFunctionCall cannot call approved then unapproved vennPolicy', async function () {
+        await sampleConsumer.setApprovedVennPolicy(approvedCallsPolicy.address, true);
+        await sampleConsumer.setApprovedVennPolicy(approvedCallsPolicy.address, false);
         const depositPayload = sampleConsumerIface.encodeFunctionData('deposit()');
         const depositCallHash = ethers.utils.solidityKeccak256(
             ['address', 'address', 'address', 'bytes', 'uint256'],
@@ -254,12 +254,12 @@ describe('Approved Calls Policy', () => {
             sampleConsumer
                 .connect(addr1)
                 .safeFunctionCall(approvedCallsPolicy.address, approvePayload, depositPayload, { value: ethers.utils.parseEther('1') })
-        ).to.be.revertedWith("FirewallConsumer: Not approved target");
+        ).to.be.revertedWith("FirewallConsumer: Not approved Venn policy");
     });
 
-    it('Firewall safeFunctionCall cannot call approved then unapproved target, but can when approved targets', async function () {
-        await sampleConsumer.setApprovedTarget(approvedCallsPolicy.address, true);
-        await sampleConsumer.setApprovedTarget(approvedCallsPolicy.address, false);
+    it('Firewall safeFunctionCall cannot call approved then unapproved vennPolicy, but can when approved vennPolicies', async function () {
+        await sampleConsumer.setApprovedVennPolicy(approvedCallsPolicy.address, true);
+        await sampleConsumer.setApprovedVennPolicy(approvedCallsPolicy.address, false);
         const depositPayload = sampleConsumerIface.encodeFunctionData('deposit()');
         const depositCallHash = ethers.utils.solidityKeccak256(
             ['address', 'address', 'address', 'bytes', 'uint256'],
@@ -294,8 +294,8 @@ describe('Approved Calls Policy', () => {
             sampleConsumer
                 .connect(addr1)
                 .safeFunctionCall(approvedCallsPolicy.address, approvePayload, depositPayload, { value: ethers.utils.parseEther('1') })
-        ).to.be.revertedWith("FirewallConsumer: Not approved target");
-        await sampleConsumer.setApprovedTarget(approvedCallsPolicy.address, true);
+        ).to.be.revertedWith("FirewallConsumer: Not approved Venn policy");
+        await sampleConsumer.setApprovedVennPolicy(approvedCallsPolicy.address, true);
         await expect(
             sampleConsumer
                 .connect(addr1)
@@ -305,7 +305,7 @@ describe('Approved Calls Policy', () => {
 
 
     it('Firewall Approved calls with signature + safeFunctionCall', async function () {
-        await sampleConsumer.setApprovedTarget(approvedCallsPolicy.address, true);
+        await sampleConsumer.setApprovedVennPolicy(approvedCallsPolicy.address, true);
         const depositPayload = sampleConsumerIface.encodeFunctionData('deposit()');
         const depositCallHash = ethers.utils.solidityKeccak256(
             ['address', 'address', 'address', 'bytes', 'uint256'],


### PR DESCRIPTION
This PR adds a new simpler version of the Firewall Consumer which can be used for integrations that do not require advanced firewall use cases.

## Contracts Added

- `FirewallConsumerStorage` - a storage container contract for `FirewallConsumer` data to be kept outside of the `FirewallConsumer`

- `SimpleUpgradeableFirewallConsumer` - a simpler version of the `FirewallConsumer` to reduce the footprint added to the consumer contract